### PR TITLE
fix: Handling unmatched events from gun and allowing adapter change

### DIFF
--- a/lib/milvex/config.ex
+++ b/lib/milvex/config.ex
@@ -71,7 +71,17 @@ defmodule Milvex.Config do
                        Zoi.integer(description: "Health check interval in milliseconds")
                        |> Zoi.min(1_000)
                        |> Zoi.optional()
-                       |> Zoi.default(30_000)
+                       |> Zoi.default(30_000),
+                     adapter:
+                       Zoi.any(description: "GRPC client adapter module")
+                       |> Zoi.optional()
+                       |> Zoi.default(GRPC.Client.Adapters.Gun),
+                     adapter_opts:
+                       Zoi.any(
+                         description: "Adapter-specific options passed to GRPC.Stub.connect"
+                       )
+                       |> Zoi.optional()
+                       |> Zoi.default([])
                    },
                    description: "Configuration options for connecting to a Milvus server",
                    example: %{

--- a/lib/milvex/connection.ex
+++ b/lib/milvex/connection.ex
@@ -192,6 +192,10 @@ defmodule Milvex.Connection do
     {:keep_state_and_data, [{:reply, from, false}]}
   end
 
+  def connecting(:info, _msg, _data) do
+    :keep_state_and_data
+  end
+
   # --- :connected state ---
 
   def connected(:enter, _old_state, data) do
@@ -225,6 +229,10 @@ defmodule Milvex.Connection do
     end
   end
 
+  def connected(:info, _msg, _data) do
+    :keep_state_and_data
+  end
+
   # --- :reconnecting state ---
 
   def reconnecting(:enter, _old_state, _data) do
@@ -245,6 +253,10 @@ defmodule Milvex.Connection do
 
   def reconnecting({:call, from}, :connected?, _data) do
     {:keep_state_and_data, [{:reply, from, false}]}
+  end
+
+  def reconnecting(:info, _msg, _data) do
+    :keep_state_and_data
   end
 
   # --- Termination ---
@@ -324,6 +336,8 @@ defmodule Milvex.Connection do
     []
     |> maybe_add_ssl(config)
     |> maybe_add_auth_headers(config)
+    |> maybe_add_adapter(config)
+    |> maybe_add_adapter_opts(config)
   end
 
   defp maybe_add_ssl(opts, %{ssl: true, ssl_options: ssl_options}) do
@@ -355,6 +369,18 @@ defmodule Milvex.Connection do
       Keyword.put(opts, :headers, headers)
     end
   end
+
+  defp maybe_add_adapter(opts, %{adapter: adapter}) when not is_nil(adapter) do
+    Keyword.put(opts, :adapter, adapter)
+  end
+
+  defp maybe_add_adapter(opts, _config), do: opts
+
+  defp maybe_add_adapter_opts(opts, %{adapter_opts: adapter_opts}) when adapter_opts != [] do
+    Keyword.put(opts, :adapter_opts, adapter_opts)
+  end
+
+  defp maybe_add_adapter_opts(opts, _config), do: opts
 
   defp perform_health_check(channel) do
     request = %CheckHealthRequest{}

--- a/mix.exs
+++ b/mix.exs
@@ -113,6 +113,7 @@ defmodule Milvex.MixProject do
       {:grpc, "~> 0.11.5"},
       {:jason, "~> 1.4"},
       {:mimic, "~> 2.2", only: :test},
+      {:mint, "~> 1.7", optional: true},
       {:mix_audit, ">= 0.0.0", only: [:dev, :test], runtime: false},
       {:nx, "~> 0.10", optional: true},
       {:protobuf, "~> 0.15.0"},


### PR DESCRIPTION
Fixes #8 : It happens because GRPC.Stub calls :gun.open, and gun makes our connection the gun process owner, and we didn't handled the GUN messages. 

Just added a catch-all to prevent the message, since our healthcheck will already catch connection failures.

This pr also allows the consumers to use Mint instead.